### PR TITLE
cmd/server: bind HTTP server with TLS if HTTPS_* variables are defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ $ curl -s localhost:8086/fed/wire/search?routingNumber=273976369 | jq .
 | `LOG_FORMAT` | Format for logging lines to be written as. | Options: `json`, `plain` - Default: `plain` |
 | `HTTP_BIND_ADDRESS` | Address for paygate to bind its HTTP server on. This overrides the command-line flag `-http.addr`. | Default: `:8086` |
 | `HTTP_ADMIN_BIND_ADDRESS` | Address for paygate to bind its admin HTTP server on. This overrides the command-line flag `-admin.addr`. | Default: `:9096` |
+| `HTTPS_CERT_FILE` | Filepath containing a certificate (or intermediate chain) to be served by the HTTP server. Requires all traffic be over secure HTTP. | Empty |
+| `HTTPS_KEY_FILE`  | Filepath of a private key matching the leaf certificate from `HTTPS_CERT_FILE`. | Empty |
 
 
 ## FedWire and FedACH data from the Federal Reserve Bank Services

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -120,10 +120,17 @@ func main() {
 
 	// Start business logic HTTP server
 	go func() {
-		logger.Log("transport", "HTTP", "addr", *httpAddr)
-		errs <- serve.ListenAndServe()
-		// TODO(adam): support TLS
-		// func (srv *Server) ListenAndServeTLS(certFile, keyFile string) error
+		if certFile, keyFile := os.Getenv("HTTPS_CERT_FILE"), os.Getenv("HTTPS_KEY_FILE"); certFile != "" && keyFile != "" {
+			logger.Log("startup", fmt.Sprintf("binding to %s for secure HTTP server", *httpAddr))
+			if err := serve.ListenAndServeTLS(certFile, keyFile); err != nil {
+				logger.Log("exit", err)
+			}
+		} else {
+			logger.Log("startup", fmt.Sprintf("binding to %s for secure HTTP server", *httpAddr))
+			if err := serve.ListenAndServe(); err != nil {
+				logger.Log("exit", err)
+			}
+		}
 	}()
 
 	// Block/Wait for an error


### PR DESCRIPTION
Fixes: https://github.com/moov-io/fed/issues/60