### PR TITLE
cmd/server: return after marshaling errNoSearchParams

### DIFF
--- a/cmd/server/search_handlers.go
+++ b/cmd/server/search_handlers.go
@@ -102,6 +102,7 @@ func searchFEDACH(logger log.Logger, searcher *searcher) http.HandlerFunc {
 				logger.Log("searchFEDWIRE", errNoSearchParams, "requestID", requestID, "userID", userID)
 			}
 			moovhttp.Problem(w, errNoSearchParams)
+			return
 		}
 
 		if req.nameOnly() {
@@ -320,6 +321,7 @@ func searchFEDWIRE(logger log.Logger, searcher *searcher) http.HandlerFunc {
 				logger.Log("searchFEDWIRE", errNoSearchParams, "requestID", requestID, "userID", userID)
 			}
 			moovhttp.Problem(w, errNoSearchParams)
+			return
 		}
 
 		if req.nameOnly() {

--- a/cmd/server/search_handlers_test.go
+++ b/cmd/server/search_handlers_test.go
@@ -231,7 +231,7 @@ func TestSearch__ACH(t *testing.T) {
 	}
 }
 
-func TestSearch__Empty(t *testing.T) {
+func TestSearch__ACHEmpty(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/fed/ach/search", nil)
 
@@ -594,5 +594,24 @@ func TestSearch__WIREStateHardLimit(t *testing.T) {
 
 	if len(wrapper.WIREParticipants) != 500 {
 		t.Errorf("exceeded the limit: %d", len(wrapper.WIREParticipants))
+	}
+}
+
+func TestSearch__WireEmpty(t *testing.T) {
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/fed/wire/search", nil)
+
+	s := searcher{}
+	if err := s.helperLoadFEDWIREFile(t); err != nil {
+		t.Fatal(err)
+	}
+
+	router := mux.NewRouter()
+	addSearchRoutes(log.NewNopLogger(), router, &s)
+	router.ServeHTTP(w, req)
+	w.Flush()
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("incorrect status code: %d", w.Code)
 	}
 }


### PR DESCRIPTION
Without this early return the search was still performed even though
we knew the request was invalid.

```
$ curl -H "x-user-id: adam" "localhost:8086/fed/ach/search?routingNumber-987654320"
{"error":"missing search parameter(s)"}
{"achParticipants":null,"wireParticipants":null}
```