### PR TITLE
fix: download fed files in-memory instead of flat files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.9.0 (Released 2022-08-03)
+
+IMPROVEMENTS
+
+- Remove `DOWNLOAD_DIRECTORY` and store downloaded files in memory.
+
 ## v0.8.1 (Released 2022-08-02)
 
 IMPROVEMENTS

--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ PONG
 | `FEDWIRE_DATA_PATH` | Filepath to Fedwire data file | `./data/fpddir.txt` |
 | `FRB_ROUTING_NUMBER` | Federal Reserve Board eServices (ABA) routing number used to download FedACH and FedWire files | Empty |
 | `FRB_DOWNLOAD_CODE` | Federal Reserve Board eServices (ABA) download code used to download FedACH and FedWire files | Empty |
-| `DOWNLOAD_DIRECTORY` | Directory for saving downloaded eServices files into | OS Temp Dir |
 | `LOG_FORMAT` | Format for logging lines to be written as. | Options: `json`, `plain` - Default: `plain` |
 | `HTTP_BIND_ADDRESS` | Address for Fed to bind its HTTP server on. This overrides the command-line flag `-http.addr`. | Default: `:8086` |
 | `HTTP_ADMIN_BIND_ADDRESS` | Address for Fed to bind its admin HTTP server on. This overrides the command-line flag `-admin.addr`. | Default: `:9096` |

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -11,10 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"time"
-
-	"github.com/moov-io/base/strx"
 )
 
 type Client struct {
@@ -53,16 +50,6 @@ func NewClient(opts *ClientOpts) (*Client, error) {
 		routingNumber: opts.RoutingNumber,
 		downloadCode:  opts.DownloadCode,
 	}, nil
-}
-
-var (
-	downloadDirectory = strx.Or(os.Getenv("DOWNLOAD_DIRECTORY"), os.TempDir())
-)
-
-func init() {
-	if _, err := os.Stat(downloadDirectory); os.IsNotExist(err) {
-		os.MkdirAll(downloadDirectory, 0777)
-	}
 }
 
 // GetList downloads an FRB list and saves it into an io.Reader.

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -10,6 +10,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestClient__fedach(t *testing.T) {
@@ -20,11 +22,10 @@ func TestClient__fedach(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	st, err := fedach.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n := st.Size(); n < 1024 {
+	buf, ok := fedach.(*bytes.Buffer)
+	require.True(t, ok)
+
+	if n := buf.Len(); n < 1024 {
 		t.Errorf("unexpected size of %d bytes", n)
 	}
 
@@ -42,11 +43,10 @@ func TestClient__fedwire(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	st, err := fedwire.Stat()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if n := st.Size(); n < 1024 {
+	buf, ok := fedwire.(*bytes.Buffer)
+	require.True(t, ok)
+
+	if n := buf.Len(); n < 1024 {
 		t.Errorf("unexpected size of %d bytes", n)
 	}
 

--- a/version.go
+++ b/version.go
@@ -5,4 +5,4 @@
 package fed
 
 // Version is the current version
-const Version = "v0.8.1"
+const Version = "v0.9.0"


### PR DESCRIPTION
This works around permission issues with the scratch container.

Issue: https://github.com/moov-io/fed/issues/186