### PR TITLE
Enable fedach and fedwire download from proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,17 +189,18 @@ PONG
 
 ### Configuration settings
 
-| Environmental Variable | Description | Default |
-|-----|-----|-----|
-| `FEDACH_DATA_PATH` | Filepath to FedACH data file | `./data/FedACHdir.txt` |
-| `FEDWIRE_DATA_PATH` | Filepath to Fedwire data file | `./data/fpddir.txt` |
-| `FRB_ROUTING_NUMBER` | Federal Reserve Board eServices (ABA) routing number used to download FedACH and FedWire files | Empty |
-| `FRB_DOWNLOAD_CODE` | Federal Reserve Board eServices (ABA) download code used to download FedACH and FedWire files | Empty |
-| `LOG_FORMAT` | Format for logging lines to be written as. | Options: `json`, `plain` - Default: `plain` |
-| `HTTP_BIND_ADDRESS` | Address for Fed to bind its HTTP server on. This overrides the command-line flag `-http.addr`. | Default: `:8086` |
-| `HTTP_ADMIN_BIND_ADDRESS` | Address for Fed to bind its admin HTTP server on. This overrides the command-line flag `-admin.addr`. | Default: `:9096` |
+| Environmental Variable | Description                                                                                                                         | Default |
+|-----|-------------------------------------------------------------------------------------------------------------------------------------|-----|
+| `FEDACH_DATA_PATH` | Filepath to FedACH data file                                                                                                        | `./data/FedACHdir.txt` |
+| `FEDWIRE_DATA_PATH` | Filepath to Fedwire data file                                                                                                       | `./data/fpddir.txt` |
+| `FRB_ROUTING_NUMBER` | Federal Reserve Board eServices (ABA) routing number used to download FedACH and FedWire files                                      | Empty |
+| `FRB_DOWNLOAD_CODE` | Federal Reserve Board eServices (ABA) download code used to download FedACH and FedWire files                                       | Empty |
+| `FRB_DOWNLOAD_URL_TEMPLATE` | URL Template for downloading files from alternate source                                                                            | `https://frbservices.org/EPaymentsDirectory/directories/%s?format=json`|
+| `LOG_FORMAT` | Format for logging lines to be written as.                                                                                          | Options: `json`, `plain` - Default: `plain` |
+| `HTTP_BIND_ADDRESS` | Address for Fed to bind its HTTP server on. This overrides the command-line flag `-http.addr`.                                      | Default: `:8086` |
+| `HTTP_ADMIN_BIND_ADDRESS` | Address for Fed to bind its admin HTTP server on. This overrides the command-line flag `-admin.addr`.                               | Default: `:9096` |
 | `HTTPS_CERT_FILE` | Filepath containing a certificate (or intermediate chain) to be served by the HTTP server. Requires all traffic be over secure HTTP. | Empty |
-| `HTTPS_KEY_FILE`  | Filepath of a private key matching the leaf certificate from `HTTPS_CERT_FILE`. | Empty |
+| `HTTPS_KEY_FILE`  | Filepath of a private key matching the leaf certificate from `HTTPS_CERT_FILE`.                                                     | Empty |
 
 #### Logos
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,14 @@ FRB_ROUTING_NUMBER=123456780
 FRB_DOWNLOAD_CODE=86cfa5a9-1ab9-4af5-bd89-0f84d546de13
 ```
 
+#### Download files from proxy
+
+Fed can download the files from a proxy or other HTTP resources. The optional URL template is configured as an environment variable. If the URL template is not configured, Fed will download the files directly from FRB eServices by default. This value is considered a template because when preparing the request Fed replaces `%s` in the path with the requested list name(`fedach` or `fedwire`).
+
+```
+FRB_DOWNLOAD_URL_TEMPLATE=https://my.example.com/files/%s?format=json
+```
+
 ### Docker
 
 We publish a [public Docker image `moov/fed`](https://hub.docker.com/r/moov/fed/) from Docker Hub or use this repository. No configuration is required to serve on `:8086` and metrics at `:9096/metrics` in Prometheus format. We also have Docker images for [OpenShift](https://quay.io/repository/moov/fed?tab=tags) published as `quay.io/moov/fed`.

--- a/cmd/server/reader.go
+++ b/cmd/server/reader.go
@@ -16,7 +16,7 @@ import (
 
 func fedACHDataFile(logger log.Logger) (io.Reader, error) {
 	file, err := attemptFileDownload(logger, "fedach")
-	if err != nil && !errors.Is(err, download.ErrMissingData) {
+	if err != nil && !errors.Is(err, download.ErrMissingConfigValue) {
 		return nil, fmt.Errorf("problem downloading fedach: %v", err)
 	}
 
@@ -36,7 +36,7 @@ func fedACHDataFile(logger log.Logger) (io.Reader, error) {
 
 func fedWireDataFile(logger log.Logger) (io.Reader, error) {
 	file, err := attemptFileDownload(logger, "fedach")
-	if err != nil && !errors.Is(err, download.ErrMissingData) {
+	if err != nil && !errors.Is(err, download.ErrMissingConfigValue) {
 		return nil, fmt.Errorf("problem downloading fedach: %v", err)
 	}
 

--- a/cmd/server/reader.go
+++ b/cmd/server/reader.go
@@ -51,20 +51,18 @@ func fedWireDataFile(logger log.Logger) (io.Reader, error) {
 func attemptFileDownload(logger log.Logger, listName string) (io.Reader, error) {
 	routingNumber := os.Getenv("FRB_ROUTING_NUMBER")
 	downloadCode := os.Getenv("FRB_DOWNLOAD_CODE")
+	downloadURL := os.Getenv("CUSTOM_DOWNLOAD_URL")
 
-	if routingNumber != "" && downloadCode != "" {
-		logger.Logf("download: attempting %s", listName)
-		client, err := download.NewClient(&download.ClientOpts{
-			RoutingNumber: routingNumber,
-			DownloadCode:  downloadCode,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("client setup: %v", err)
-		}
-		return client.GetList(listName)
+	logger.Logf("download: attempting %s", listName)
+	client, err := download.NewClient(&download.ClientOpts{
+		RoutingNumber: routingNumber,
+		DownloadCode:  downloadCode,
+		DownloadURL:   downloadURL,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("client setup: %v", err)
 	}
-
-	return nil, nil
+	return client.GetList(listName)
 }
 
 func readDataFilepath(env, fallback string) string {

--- a/cmd/server/reader.go
+++ b/cmd/server/reader.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/fed"
@@ -15,16 +16,19 @@ import (
 )
 
 func fedACHDataFile(logger log.Logger) (io.Reader, error) {
-	if file, err := attemptFileDownload(logger, "fedach"); file != nil {
-		return file, nil
-	} else if err != nil {
+	file, err := attemptFileDownload(logger, "fedach")
+	if err != nil && !strings.Contains(err.Error(), download.MissingRoutingNumberErr) && !strings.Contains(err.Error(), download.MissingDownloadCodeErr) {
 		return nil, fmt.Errorf("problem downloading fedach: %v", err)
+	}
+
+	if file != nil {
+		return file, nil
 	}
 
 	path := readDataFilepath("FEDACH_DATA_PATH", "./data/FedACHdir.txt")
 	logger.Logf("search: loading %s for ACH data", path)
 
-	file, err := os.Open(path)
+	file, err = os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("problem opening %s: %v", path, err)
 	}
@@ -32,16 +36,19 @@ func fedACHDataFile(logger log.Logger) (io.Reader, error) {
 }
 
 func fedWireDataFile(logger log.Logger) (io.Reader, error) {
-	if file, err := attemptFileDownload(logger, "fedwire"); file != nil {
+	file, err := attemptFileDownload(logger, "fedach")
+	if err != nil && !strings.Contains(err.Error(), download.MissingRoutingNumberErr) && !strings.Contains(err.Error(), download.MissingDownloadCodeErr) {
+		return nil, fmt.Errorf("problem downloading fedach: %v", err)
+	}
+
+	if file != nil {
 		return file, nil
-	} else if err != nil {
-		return nil, fmt.Errorf("problem downloading fedwire: %v", err)
 	}
 
 	path := readDataFilepath("FEDWIRE_DATA_PATH", "./data/fpddir.txt")
 	logger.Logf("search: loading %s for Wire data", path)
 
-	file, err := os.Open(path)
+	file, err = os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("problem opening %s: %v", path, err)
 	}

--- a/cmd/server/reader.go
+++ b/cmd/server/reader.go
@@ -5,19 +5,18 @@
 package main
 
 import (
+	"errors"
 	"fmt"
-	"io"
-	"os"
-	"strings"
-
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/fed"
 	"github.com/moov-io/fed/pkg/download"
+	"io"
+	"os"
 )
 
 func fedACHDataFile(logger log.Logger) (io.Reader, error) {
 	file, err := attemptFileDownload(logger, "fedach")
-	if err != nil && !strings.Contains(err.Error(), download.MissingRoutingNumberErr) && !strings.Contains(err.Error(), download.MissingDownloadCodeErr) {
+	if err != nil && !errors.Is(err, download.ErrMissingData) {
 		return nil, fmt.Errorf("problem downloading fedach: %v", err)
 	}
 
@@ -37,7 +36,7 @@ func fedACHDataFile(logger log.Logger) (io.Reader, error) {
 
 func fedWireDataFile(logger log.Logger) (io.Reader, error) {
 	file, err := attemptFileDownload(logger, "fedach")
-	if err != nil && !strings.Contains(err.Error(), download.MissingRoutingNumberErr) && !strings.Contains(err.Error(), download.MissingDownloadCodeErr) {
+	if err != nil && !errors.Is(err, download.ErrMissingData) {
 		return nil, fmt.Errorf("problem downloading fedach: %v", err)
 	}
 
@@ -67,7 +66,7 @@ func attemptFileDownload(logger log.Logger, listName string) (io.Reader, error) 
 		DownloadURL:   downloadURL,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("client setup: %v", err)
+		return nil, fmt.Errorf("client setup: %w", err)
 	}
 	return client.GetList(listName)
 }

--- a/cmd/server/reader.go
+++ b/cmd/server/reader.go
@@ -51,7 +51,7 @@ func fedWireDataFile(logger log.Logger) (io.Reader, error) {
 func attemptFileDownload(logger log.Logger, listName string) (io.Reader, error) {
 	routingNumber := os.Getenv("FRB_ROUTING_NUMBER")
 	downloadCode := os.Getenv("FRB_DOWNLOAD_CODE")
-	downloadURL := os.Getenv("CUSTOM_DOWNLOAD_URL")
+	downloadURL := os.Getenv("FRB_DOWNLOAD_URL_TEMPLATE")
 
 	logger.Logf("download: attempting %s", listName)
 	client, err := download.NewClient(&download.ClientOpts{

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -14,6 +14,9 @@ import (
 	"time"
 )
 
+var MissingRoutingNumberErr = "missing routing number"
+var MissingDownloadCodeErr = "missing download code"
+
 type Client struct {
 	httpClient *http.Client
 
@@ -40,11 +43,13 @@ func NewClient(opts *ClientOpts) (*Client, error) {
 		}
 	}
 
+	// the client needs either routing number && download code OR download URL
+
 	if opts.RoutingNumber == "" {
-		return nil, errors.New("missing routing number")
+		return nil, errors.New(MissingRoutingNumberErr)
 	}
 	if opts.DownloadCode == "" {
-		return nil, errors.New("missing download code")
+		return nil, errors.New(MissingDownloadCodeErr)
 	}
 
 	if opts.DownloadURL == "" {

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -14,7 +14,13 @@ import (
 	"time"
 )
 
-var ErrMissingData = errors.New("missing data")
+const DefaultFRBDownloadURLTemplate = "https://frbservices.org/EPaymentsDirectory/directories/%s?format=json"
+
+var (
+	ErrMissingConfigValue   = errors.New("missing config value")
+	ErrMissingRoutingNumber = errors.New("missing routing number")
+	ErrMissingDownloadCD    = errors.New("missing download code")
+)
 
 type Client struct {
 	httpClient *http.Client
@@ -42,17 +48,16 @@ func NewClient(opts *ClientOpts) (*Client, error) {
 		}
 	}
 
-	// the client needs either routing number && download code OR download URL
+	if opts.RoutingNumber == "" {
+		return nil, fmt.Errorf("%w: %w", ErrMissingConfigValue, ErrMissingRoutingNumber)
+	}
 
 	if opts.RoutingNumber == "" {
-		return nil, ErrMissingData
-	}
-	if opts.DownloadCode == "" {
-		return nil, ErrMissingData
+		return nil, fmt.Errorf("%w: %w", ErrMissingConfigValue, ErrMissingDownloadCD)
 	}
 
 	if opts.DownloadURL == "" {
-		opts.DownloadURL = "https://frbservices.org/EPaymentsDirectory/directories/%s?format=json"
+		opts.DownloadURL = DefaultFRBDownloadURLTemplate
 	}
 
 	return &Client{

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -14,8 +14,7 @@ import (
 	"time"
 )
 
-var MissingRoutingNumberErr = "missing routing number"
-var MissingDownloadCodeErr = "missing download code"
+var ErrMissingData = errors.New("missing data")
 
 type Client struct {
 	httpClient *http.Client
@@ -46,10 +45,10 @@ func NewClient(opts *ClientOpts) (*Client, error) {
 	// the client needs either routing number && download code OR download URL
 
 	if opts.RoutingNumber == "" {
-		return nil, errors.New(MissingRoutingNumberErr)
+		return nil, ErrMissingData
 	}
 	if opts.DownloadCode == "" {
-		return nil, errors.New(MissingDownloadCodeErr)
+		return nil, ErrMissingData
 	}
 
 	if opts.DownloadURL == "" {

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -44,7 +44,7 @@ func TestClient__fedach_custom_url(t *testing.T) {
 	}))
 	defer mockHTTPServer.Close()
 
-	err := os.Setenv("CUSTOM_DOWNLOAD_URL", mockHTTPServer.URL+"/%s")
+	err := os.Setenv("FRB_DOWNLOAD_URL_TEMPLATE", mockHTTPServer.URL+"/%s")
 	err = os.Setenv("FRB_ROUTING_NUMBER", "123456789")
 	err = os.Setenv("FRB_DOWNLOAD_CODE", "a1b2c3d4-123b-9876-1234-z1x2y3a1b2c3")
 	require.NoError(t, err)
@@ -97,7 +97,7 @@ func TestClient__wire_custom_url(t *testing.T) {
 	}))
 	defer mockHTTPServer.Close()
 
-	err := os.Setenv("CUSTOM_DOWNLOAD_URL", mockHTTPServer.URL+"/%s")
+	err := os.Setenv("FRB_DOWNLOAD_URL_TEMPLATE", mockHTTPServer.URL+"/%s")
 	err = os.Setenv("FRB_ROUTING_NUMBER", "123456789")
 	err = os.Setenv("FRB_DOWNLOAD_CODE", "a1b2c3d4-123b-9876-1234-z1x2y3a1b2c3")
 	require.NoError(t, err)


### PR DESCRIPTION
`frbservices.org` is not always available when we need to download the `fedach` or `fedwire` data. The ability to get this data from a proxy or cache instead of `frbservices.org` would be very helpful.

This PR enables Fed to fetch data from a custom URL(i.e. private service or NGINX). The custom URL must be set in the `CUSTOM_DOWNLOAD_URL` environment variable. The custom URL must include the formatting directive `%s` where `%s` is the listName. This value is interpolated into the URL at the time the request is made.

Ex: `"https://frbservices.org/EPaymentsDirectory/directories/%s?format=json"`

If this environment variable is not supplied, Fed defaults to the url in the above example.