### PR TITLE
test(fuzz): add ACH and WIRE directory dictionary fuzzers

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,40 @@
+name: Go Fuzz Testing
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    name: Fuzz
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        command:
+          - "go test . -fuzz FuzzACHDictionary -fuzztime 10m"
+          - "go test . -fuzz FuzzWIREDictionary -fuzztime 10m"
+
+    steps:
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v7
+      with:
+        go-version: stable
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v7
+      with:
+        fetch-depth: 0
+
+    - name: Fuzz
+      run: ${{ matrix.command }}
+
+    - name: Report Failures
+      if: ${{ failure() }}
+      run: |
+        find . -path '*/testdata/fuzz/*' -type f 2>/dev/null | xargs -r -n1 tail -n +1 -v || true

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,85 @@
+package fed_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/moov-io/fed"
+)
+
+func FuzzACHDictionary(f *testing.F) {
+	populateCorpus(f, "FedACH", "fedach", ".txt", ".json")
+
+	f.Fuzz(func(t *testing.T, contents string) {
+		if len(contents) > 2<<20 {
+			t.Skip()
+		}
+
+		dict := fed.NewACHDictionary()
+		if err := dict.Read(strings.NewReader(contents)); err != nil {
+			return
+		}
+		// Search APIs must not panic on loaded data
+		_ = dict.RoutingNumberSearchSingle("021000021")
+		_ = dict.FinancialInstitutionSearchSingle("JPMORGAN")
+		_, _ = dict.RoutingNumberSearch("0210", 5)
+		_ = dict.FinancialInstitutionSearch("BANK", 5)
+		_ = dict.StateFilter("NY")
+		_ = dict.CityFilter("NEW YORK")
+	})
+}
+
+func FuzzWIREDictionary(f *testing.F) {
+	populateCorpus(f, "fpddir", "FedWire", "wire", ".txt", ".json")
+
+	f.Fuzz(func(t *testing.T, contents string) {
+		if len(contents) > 2<<20 {
+			t.Skip()
+		}
+
+		dict := fed.NewWIREDictionary()
+		if err := dict.Read(strings.NewReader(contents)); err != nil {
+			return
+		}
+		_ = dict.RoutingNumberSearchSingle("021000021")
+		_ = dict.FinancialInstitutionSearchSingle("JPMORGAN")
+		_, _ = dict.RoutingNumberSearch("0210", 5)
+		_ = dict.FinancialInstitutionSearch("BANK", 5)
+		_ = dict.StateFilter("NY")
+		_ = dict.CityFilter("NEW YORK")
+	})
+}
+
+func populateCorpus(f *testing.F, nameHints ...string) {
+	f.Helper()
+
+	f.Add("")
+	f.Add("{}")
+	f.Add("[]")
+
+	_ = filepath.Walk("data", func(path string, info fs.FileInfo, err error) error {
+		if err != nil || info == nil || info.IsDir() {
+			return nil
+		}
+		base := strings.ToLower(filepath.Base(path))
+		// Include all data files; nameHints just document intent
+		_ = nameHints
+		if strings.HasSuffix(base, ".txt") || strings.HasSuffix(base, ".json") {
+			bs, err := os.ReadFile(path)
+			if err != nil {
+				return nil
+			}
+			// Fed directory files can be large; cap seeds
+			if len(bs) > 512*1024 {
+				// Still seed a prefix so format is represented
+				f.Add(string(bs[:min(len(bs), 64*1024)]))
+				return nil
+			}
+			f.Add(string(bs))
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
## Summary
Add fuzzers for `ACHDictionary.Read` and `WIREDictionary.Read` plus common search helpers, seeded from `data/` Fed directory samples (with size caps).

## Test plan
- [x] `go test` for affected packages
- [x] `go test -run='^$' -fuzz=Fuzz... -fuzztime=3s` smoke on new/updated fuzzers
- [x] Regression tests for any panics fixed by fuzzing