### PR TITLE
fix(server): require CORS origin allowlist for credentialed responses

### DIFF
--- a/cmd/server/cors.go
+++ b/cmd/server/cors.go
@@ -1,0 +1,120 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/moov-io/base/log"
+
+	"github.com/go-kit/kit/metrics"
+)
+
+// CORSAllowedOriginsEnv is a comma-separated list of exact Origins permitted for
+// credentialed CORS. Example: "https://moov.io,https://dashboard.moov.io".
+// Localhost (http://localhost:<port>) remains allowed for development.
+//
+// Temporary FED-local allowlist until moov-io/base#509 lands and is bumped here.
+const CORSAllowedOriginsEnv = "MOOV_CORS_ALLOW_ORIGINS"
+
+var (
+	corsAllowlistOnce sync.Once
+	corsAllowlist     map[string]struct{}
+)
+
+func loadCORSAllowlist() map[string]struct{} {
+	corsAllowlistOnce.Do(func() {
+		corsAllowlist = make(map[string]struct{})
+		for _, part := range strings.Split(os.Getenv(CORSAllowedOriginsEnv), ",") {
+			origin := strings.TrimSpace(part)
+			if origin != "" {
+				corsAllowlist[origin] = struct{}{}
+			}
+		}
+	})
+	return corsAllowlist
+}
+
+func resetCORSAllowlistForTest() {
+	corsAllowlistOnce = sync.Once{}
+	corsAllowlist = nil
+}
+
+func originAllowedForCORS(origin string) bool {
+	if origin == "" {
+		return false
+	}
+	if strings.HasPrefix(origin, "http://localhost:") {
+		return true
+	}
+	_, ok := loadCORSAllowlist()[origin]
+	return ok
+}
+
+func setAccessControlAllowHeaders(w http.ResponseWriter, origin string) {
+	if !originAllowedForCORS(origin) {
+		return
+	}
+	w.Header().Set("Access-Control-Allow-Origin", origin)
+	w.Header().Set("Access-Control-Allow-Methods", "GET,POST,PATCH,DELETE,OPTIONS")
+	w.Header().Set("Access-Control-Allow-Headers", "Cookie,X-User-Id,X-Request-Id,Content-Type")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+}
+
+func addCORSHandler(r *mux.Router) {
+	r.Methods("OPTIONS").HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		origin := req.Header.Get("Origin")
+		if origin == "" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		setAccessControlAllowHeaders(w, origin)
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+// responseWriter mirrors moov-io/base Wrap metrics but uses the local CORS
+// allowlist instead of reflecting arbitrary https Origins.
+type responseWriter struct {
+	http.ResponseWriter
+	start          time.Time
+	request        *http.Request
+	metric         metrics.Histogram
+	headersWritten bool
+	log            log.Logger
+}
+
+func (w *responseWriter) WriteHeader(code int) {
+	if w == nil || w.headersWritten {
+		return
+	}
+	w.headersWritten = true
+	setAccessControlAllowHeaders(w, w.request.Header.Get("Origin"))
+	defer w.ResponseWriter.WriteHeader(code)
+
+	diff := time.Since(w.start)
+	if w.metric != nil {
+		w.metric.Observe(diff.Seconds())
+	}
+	if w.ResponseWriter.Header().Get("Content-Type") == "" {
+		w.ResponseWriter.Header().Set("Content-Type", "text/plain")
+		w.ResponseWriter.Header().Set("X-Content-Type-Options", "nosniff")
+	}
+}
+
+func wrapResponseWriterAllowlist(logger log.Logger, m metrics.Histogram, w http.ResponseWriter, r *http.Request) http.ResponseWriter {
+	return &responseWriter{
+		ResponseWriter: w,
+		start:          time.Now(),
+		request:        r,
+		metric:         m,
+		log:            logger,
+	}
+}

--- a/cmd/server/cors_test.go
+++ b/cmd/server/cors_test.go
@@ -1,0 +1,60 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func withCORSAllowOrigins(t *testing.T, origins string) {
+	t.Helper()
+	t.Setenv(CORSAllowedOriginsEnv, origins)
+	resetCORSAllowlistForTest()
+	t.Cleanup(resetCORSAllowlistForTest)
+}
+
+func TestCORSRejectsUnlistedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	w := httptest.NewRecorder()
+	setAccessControlAllowHeaders(w, "https://evil.example")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no ACAO, got %q", v)
+	}
+}
+
+func TestCORSAllowsListedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	w := httptest.NewRecorder()
+	setAccessControlAllowHeaders(w, "https://moov.io")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "https://moov.io" {
+		t.Errorf("got %q", v)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Credentials"); v != "true" {
+		t.Errorf("got credentials %q", v)
+	}
+}
+
+func TestCORSAllowsLocalhost(t *testing.T) {
+	withCORSAllowOrigins(t, "")
+	w := httptest.NewRecorder()
+	setAccessControlAllowHeaders(w, "http://localhost:3000")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "http://localhost:3000" {
+		t.Errorf("got %q", v)
+	}
+}
+
+func TestPingCORSUsesAllowlist(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	req := httptest.NewRequest("GET", "/ping", nil)
+	req.Header.Set("Origin", "https://moov.io")
+	w := httptest.NewRecorder()
+	setAccessControlAllowHeaders(w, req.Header.Get("Origin"))
+	if w.Header().Get("Access-Control-Allow-Origin") != "https://moov.io" {
+		t.Fatal("expected listed origin")
+	}
+	_ = http.StatusOK
+}

--- a/cmd/server/http.go
+++ b/cmd/server/http.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"strings"
 
-	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/base/log"
 
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -25,5 +24,6 @@ var (
 
 func wrapResponseWriter(logger log.Logger, w http.ResponseWriter, r *http.Request) http.ResponseWriter {
 	route := fmt.Sprintf("%s%s", strings.ToLower(r.Method), strings.Replace(r.URL.Path, "/", "-", -1)) // TODO: filter out random ID's later
-	return moovhttp.Wrap(logger, routeHistogram.With("route", route), w, r)
+	// Use allowlisted CORS wrapper (not moovhttp.Wrap) until moov-io/base#509 is bumped.
+	return wrapResponseWriterAllowlist(logger, routeHistogram.With("route", route), w, r)
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/moov-io/base/admin"
-	moovhttp "github.com/moov-io/base/http"
 	"github.com/moov-io/base/http/bind"
 	"github.com/moov-io/base/log"
 	"github.com/moov-io/fed"
@@ -60,7 +59,7 @@ func main() {
 
 	// Setup business HTTP routes
 	router := mux.NewRouter()
-	moovhttp.AddCORSHandler(router)
+	addCORSHandler(router)
 	addPingRoute(router)
 
 	// Start business HTTP server
@@ -167,7 +166,7 @@ func main() {
 
 func addPingRoute(r *mux.Router) {
 	r.Methods("GET").Path("/ping").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		moovhttp.SetAccessControlAllowHeaders(w, r.Header.Get("Origin"))
+		setAccessControlAllowHeaders(w, r.Header.Get("Origin"))
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("PONG"))


### PR DESCRIPTION
## Summary
- FED used `moovhttp.Wrap` / `AddCORSHandler` / `SetAccessControlAllowHeaders` from `moov-io/base@v0.62.1`, which reflects any `https://` Origin with credentials.
- Add FED-local allowlist via `MOOV_CORS_ALLOW_ORIGINS`; keep `http://localhost:<port>` for local development.
- Temporary until [moov-io/base#509](https://github.com/moov-io/base/pull/509) merges and can be bumped (sibling of [ach#1830](https://github.com/moov-io/ach/pull/1830)).

## Test plan
- [x] `go test ./cmd/server/ -run CORS -count=1`
- [x] Unlisted `https://evil.example` gets no ACAO/ACAC

## Deploy note
Set `MOOV_CORS_ALLOW_ORIGINS=https://moov.io,...` where credentialed browser calls are expected.


Made with [Cursor](https://cursor.com)