### PR TITLE
fix(deps): bump moov-io/base to v0.63.0 for CORS origin allowlist

### DIFF
--- a/cmd/server/cors_test.go
+++ b/cmd/server/cors_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 The Moov Authors
+// Use of this source code is governed by an Apache License
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	moovhttp "github.com/moov-io/base/http"
+)
+
+func withCORSAllowOrigins(t *testing.T, origins ...string) {
+	t.Helper()
+	moovhttp.SetCORSAllowedOrigins(origins)
+	t.Cleanup(moovhttp.ResetCORSAllowlistForTest)
+}
+
+func TestCORSRejectsUnlistedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	w := httptest.NewRecorder()
+	moovhttp.SetAccessControlAllowHeaders(w, "https://evil.example")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "" {
+		t.Errorf("expected no ACAO, got %q", v)
+	}
+}
+
+func TestCORSAllowsListedOrigin(t *testing.T) {
+	withCORSAllowOrigins(t, "https://moov.io")
+	w := httptest.NewRecorder()
+	moovhttp.SetAccessControlAllowHeaders(w, "https://moov.io")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "https://moov.io" {
+		t.Errorf("got %q", v)
+	}
+	if v := w.Header().Get("Access-Control-Allow-Credentials"); v != "true" {
+		t.Errorf("got credentials %q", v)
+	}
+}
+
+func TestCORSAllowsLocalhost(t *testing.T) {
+	withCORSAllowOrigins(t)
+	w := httptest.NewRecorder()
+	moovhttp.SetAccessControlAllowHeaders(w, "http://localhost:3000")
+	if v := w.Header().Get("Access-Control-Allow-Origin"); v != "http://localhost:3000" {
+		t.Errorf("got %q", v)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/antihax/optional v1.0.0
 	github.com/go-kit/kit v0.13.0
 	github.com/gorilla/mux v1.8.1
-	github.com/moov-io/base v0.62.1
+	github.com/moov-io/base v0.63.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/stretchr/testify v1.11.1
 	github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342
@@ -27,7 +27,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
-	github.com/rickar/cal/v2 v2.1.28 // indirect
+	github.com/rickar/cal/v2 v2.1.29 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -24,8 +24,8 @@ github.com/klauspost/compress v1.19.1 h1:VsB4HPswih7mmZ8WleSFQ75c/Ui1M4trX5oAsJn
 github.com/klauspost/compress v1.19.1/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/moov-io/base v0.62.1 h1:nM+RdTWMsWaUd572D/Hitgf+wND6vnfnYjM9MNWLd7g=
-github.com/moov-io/base v0.62.1/go.mod h1:Rndo5mNk38K74u6zTA8K5pxpsgmnK7CirAf++zXuWuM=
+github.com/moov-io/base v0.63.0 h1:J2dGj5z5X2dbLumWkbCCjM6rWycf/Zfdvk31fHJQjZk=
+github.com/moov-io/base v0.63.0/go.mod h1:7lW1P0fiFOrINtS2zoxYtvTgvhdI0EcGSi5J//pIZcY=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
@@ -38,8 +38,8 @@ github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/rickar/cal/v2 v2.1.28 h1:PLNjsw5YrCMkcE+EtD/wFh0Ys+a4Qp9yN6SKyksVso0=
-github.com/rickar/cal/v2 v2.1.28/go.mod h1:/fdlMcx7GjPlIBibMzOM9gMvDBsrK+mOtRXdTzUqV/A=
+github.com/rickar/cal/v2 v2.1.29 h1:VDs0S1RZTD7DUbc/pDBdZyTMOQn0uOf5Qjz3sIpaeAU=
+github.com/rickar/cal/v2 v2.1.29/go.mod h1:/fdlMcx7GjPlIBibMzOM9gMvDBsrK+mOtRXdTzUqV/A=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/xrash/smetrics v0.0.0-20250705151800-55b8f293f342 h1:FnBeRrxr7OU4VvAzt5X7s6266i6cSVkkFPS0TuXWbIg=


### PR DESCRIPTION
## Summary
- Bump `github.com/moov-io/base` to **[v0.63.0](https://github.com/moov-io/base/releases/tag/v0.63.0)**.
- Credentialed CORS now uses base's shared allowlist (`MOOV_CORS_ALLOW_ORIGINS` / `SetCORSAllowedOrigins`) via existing `AddCORSHandler` / `SetAccessControlAllowHeaders` / `Wrap` call sites — **no service-local CORS fork**.
- Tests cover listed / unlisted / localhost Origins using the base API.

Supersedes #443 (local allowlist copy).

## Deploy note
Set `MOOV_CORS_ALLOW_ORIGINS=https://…` (exact browser Origins) wherever credentialed cross-origin browser calls are expected. Server-to-server clients are unaffected.

## Test plan
- [x] `go test` for CORS-related packages
- [ ] Confirm deploy sets `MOOV_CORS_ALLOW_ORIGINS` before relying on browser credentialed CORS